### PR TITLE
Add shell compatability for install script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,10 @@
+	echo 'building docker image...'
+	{ 
+		docker build -t team_rocket_app .
+	} || {
+		echo 'docker build failed.'
+		echo 'Please report the issue to https://github.com/menghaoyu2002/CSC302-TeamRocket/issues with your terminal output'
+		exit 1
+	}
+
+	echo 'build complete!'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,6 @@
 	echo 'building docker image...'
 	{ 
-		docker build -t team_rocket_app .
+		docker build -t team_rocket_app
 	} || {
 		echo 'docker build failed.'
 		echo 'Please report the issue to https://github.com/menghaoyu2002/CSC302-TeamRocket/issues with your terminal output'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,18 +98,18 @@ install() {
   OS=$(echo $OS | awk '{print $1;}')
 
   # handle which download urls to use based on distro
-  if [[ "$OS" == "Ubuntu" ]]; then
+  if [ "$OS" = "Ubuntu" ]; then
     GPG_LINK="https://download.docker.com/linux/ubuntu/gpg"
     REPO_LINK="https://download.docker.com/linux/ubuntu"
     install
-  elif [[ "$OS" == "Debian" ]]; then 
+  elif [ "$OS" = "Debian" ]; then 
     GPG_LINK="https://download.docker.com/linux/debian/gpg"
     REPO_LINK="https://download.docker.com/linux/debian"
     install
-  elif [[ "$OS" == "Fedora" ]]; then
+  elif [ "$OS" = "Fedora" ]; then
     REPO_LINK="https://download.docker.com/linux/fedora/docker-ce.repo"
     install
-  elif [[ "$OS" == "CentOS" ]]; then 
+  elif [ "$OS" = "CentOS" ]; then 
     REPO_LINK="https://download.docker.com/linux/centos/docker-ce.repo"
     install
   else 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,9 @@
+echo 'starting the applicatoin...'
+{
+	docker run --rm --name team_rocket_app team_rocket_app
+} || {
+	echo 'Failed. There was an issue running the applicatoin with its docker image.'
+	echo 'Please report the issue to https://github.com/menghaoyu2002/CSC302-TeamRocket/issues with your terminal output'
+	exit 1
+}
+echo 'Application finished running.'

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,8 +1,8 @@
-echo 'starting the applicatoin...'
+echo 'starting the application...'
 {
 	docker run --rm --name team_rocket_app team_rocket_app
 } || {
-	echo 'Failed. There was an issue running the applicatoin with its docker image.'
+	echo 'Failed. There was an issue running the application with its docker image.'
 	echo 'Please report the issue to https://github.com/menghaoyu2002/CSC302-TeamRocket/issues with your terminal output'
 	exit 1
 }


### PR DESCRIPTION
Before, our script could only run on bash. What if bash isn't installed on the host's machine? Let's stick with pure shell script.

What if the user does not have shell? Well.. I don't know.